### PR TITLE
Package reorganization: s/io.pivotal/org.cftoolsuite/g

### DIFF
--- a/footprints/local/support/config-server/pom.xml
+++ b/footprints/local/support/config-server/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
 				<groupId>org.cyclonedx</groupId>
 				<artifactId>cyclonedx-maven-plugin</artifactId>
-				<version>2.7.11</version>
+				<version>2.8.0</version>
 				<executions>
 					<execution>
 						<phase>validate</phase>

--- a/footprints/local/support/config-server/pom.xml
+++ b/footprints/local/support/config-server/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.pivotal.cfapp.support</groupId>
+        <groupId>org.cftoolsuite.cfapp.support</groupId>
         <artifactId>cf-toolsuite-support-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/footprints/local/support/config-server/src/main/java/org/cftoolsuite/cfapp/support/config/App.java
+++ b/footprints/local/support/config-server/src/main/java/org/cftoolsuite/cfapp/support/config/App.java
@@ -1,11 +1,11 @@
-package io.pivotal.cfapp.support.discovery;
+package org.cftoolsuite.cfapp.support.config;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+import org.springframework.cloud.config.server.EnableConfigServer;
 
 @SpringBootApplication
-@EnableEurekaServer
+@EnableConfigServer
 public class App {
 
 	public static void main(String[] args) {

--- a/footprints/local/support/discovery-service/pom.xml
+++ b/footprints/local/support/discovery-service/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.pivotal.cfapp.support</groupId>
+        <groupId>org.cftoolsuite.cfapp.support</groupId>
         <artifactId>cf-toolsuite-support-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/footprints/local/support/discovery-service/pom.xml
+++ b/footprints/local/support/discovery-service/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
 				<groupId>org.cyclonedx</groupId>
 				<artifactId>cyclonedx-maven-plugin</artifactId>
-				<version>2.7.11</version>
+				<version>2.8.0</version>
 				<executions>
 					<execution>
 						<phase>validate</phase>

--- a/footprints/local/support/discovery-service/src/main/java/org/cftoolsuite/cfapp/support/discovery/App.java
+++ b/footprints/local/support/discovery-service/src/main/java/org/cftoolsuite/cfapp/support/discovery/App.java
@@ -1,14 +1,11 @@
-package io.pivotal.cfapp.support.console;
+package org.cftoolsuite.cfapp.support.discovery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-
-import de.codecentric.boot.admin.server.config.EnableAdminServer;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 
 @SpringBootApplication
-@EnableAdminServer
-@EnableDiscoveryClient
+@EnableEurekaServer
 public class App {
 
 	public static void main(String[] args) {

--- a/footprints/local/support/microservices-console/pom.xml
+++ b/footprints/local/support/microservices-console/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.pivotal.cfapp.support</groupId>
+        <groupId>org.cftoolsuite.cfapp.support</groupId>
         <artifactId>cf-toolsuite-support-parent</artifactId>
         <version>1.0-SNAPSHOT</version>
     </parent>

--- a/footprints/local/support/microservices-console/pom.xml
+++ b/footprints/local/support/microservices-console/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
 				<groupId>org.cyclonedx</groupId>
 				<artifactId>cyclonedx-maven-plugin</artifactId>
-				<version>2.7.11</version>
+				<version>2.8.0</version>
 				<executions>
 					<execution>
 						<phase>validate</phase>

--- a/footprints/local/support/microservices-console/src/main/java/org/cftoolsuite/cfapp/support/console/App.java
+++ b/footprints/local/support/microservices-console/src/main/java/org/cftoolsuite/cfapp/support/console/App.java
@@ -1,11 +1,14 @@
-package io.pivotal.cfapp.support.config;
+package org.cftoolsuite.cfapp.support.console;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.config.server.EnableConfigServer;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+import de.codecentric.boot.admin.server.config.EnableAdminServer;
 
 @SpringBootApplication
-@EnableConfigServer
+@EnableAdminServer
+@EnableDiscoveryClient
 public class App {
 
 	public static void main(String[] args) {

--- a/footprints/local/support/pom.xml
+++ b/footprints/local/support/pom.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.pivotal.cfapp.support</groupId>
+    <groupId>org.cftoolsuite.cfapp.support</groupId>
     <artifactId>cf-toolsuite-support-parent</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -27,7 +27,7 @@
         <developer>
             <id>cphillipson</id>
             <name>Chris Phillipson</name>
-            <email>cphillipson@pivotal.io</email>
+            <email>cphillipson@cftoolsuite.org</email>
             <url>https://pivotal.io</url>
             <roles>
                 <role>architect</role>
@@ -111,8 +111,8 @@
                 <version>4.3</version>
                 <configuration>
                     <properties>
-                        <owner>io.pivotal.cf-butler</owner>
-                        <email>cphillipson@pivotal.io</email>
+                        <owner>org.cftoolsuite.cfapp.support</owner>
+                        <email>cphillipson@cftoolsuite.org</email>
                     </properties>
                     <licenseSets>
                         <licenseSet>
@@ -307,7 +307,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2023.0.0</version>
+                <version>2023.0.1</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/scripts/build-container-images.sh
+++ b/scripts/build-container-images.sh
@@ -13,19 +13,12 @@ cd /tmp
 
 if [ "$CLONE_PROJECTS" == "true" ]; then
   echo "-- Cloning Github repositories"
-  gh repo clone cf-toolsuite/spring-boot-starter-runtime-metadata
   gh repo clone cf-toolsuite/cf-butler
   gh repo clone cf-toolsuite/cf-hoover
   gh repo clone cf-toolsuite/cf-hoover-ui
   gh repo clone cf-toolsuite/cf-archivist
   gh repo clone cf-toolsuite/home
 fi
-
-echo "-- Building spring-boot-starter-runtime-metadata"
-
-cd spring-boot-starter-runtime-metadata
-./mvnw clean install
-cd ..
 
 echo "-- Building container images"
 
@@ -43,6 +36,7 @@ fi
 if [ "$MODE" == "hoover-only" ] || [ "$MODE" == "full-install" ]; then
   cd cf-hoover
   pack build cftoolsuite/cf-hoover \
+    --env BP_NATIVE_IMAGE=true \
     --path . \
     --env BP_MAVEN_ACTIVE_PROFILES=expose-runtime-metadata \
     --env BP_JVM_VERSION=21.* \
@@ -54,6 +48,7 @@ fi
 if [ "$MODE" == "hoover-only" ] || [ "$MODE" == "full-install" ]; then
   cd cf-hoover-ui
   pack build cftoolsuite/cf-hoover-ui \
+    --env BP_NATIVE_IMAGE=true \
     --path . \
     --env BP_MAVEN_BUILD_ARGUMENTS="clean verify --batch-mode -DskipTests" \
     --env BP_MAVEN_ACTIVE_PROFILES=production,expose-runtime-metadata \

--- a/scripts/e2e-install.sh
+++ b/scripts/e2e-install.sh
@@ -79,7 +79,6 @@ cd /tmp
 
 if [ "$CLONE_PROJECTS" == "true" ]; then
   echo "-- Cloning Github repositories"
-  gh repo clone cf-toolsuite/spring-boot-starter-runtime-metadata
   gh repo clone cf-toolsuite/cf-butler
   gh repo fork cf-toolsuite/cf-butler-sample-config --fork-name cf-butler-config --clone --remote
   gh repo clone cf-toolsuite/cf-hoover
@@ -90,11 +89,7 @@ if [ "$CLONE_PROJECTS" == "true" ]; then
 fi
 
 if [ "$BUILD_PROJECTS" == "true" ]; then
-  echo "-- Building library and applications"
-
-  cd spring-boot-starter-runtime-metadata
-  ./mvnw clean install
-  cd ..
+  echo "-- Building applications"
 
   if [ "$MODE" == "butler-only" ] || [ "$MODE" == "full-install" ]; then
     cd cf-butler

--- a/scripts/publish-container-images.sh
+++ b/scripts/publish-container-images.sh
@@ -16,19 +16,12 @@ cd /tmp
 
 if [ "$CLONE_PROJECTS" == "true" ]; then
   echo "-- Cloning Github repositories"
-  gh repo clone cf-toolsuite/spring-boot-starter-runtime-metadata
   gh repo clone cf-toolsuite/cf-butler
   gh repo clone cf-toolsuite/cf-hoover
   gh repo clone cf-toolsuite/cf-hoover-ui
   gh repo clone cf-toolsuite/cf-archivist
   gh repo clone cf-toolsuite/home
 fi
-
-echo "-- Building spring-boot-starter-runtime-metadata"
-
-cd spring-boot-starter-runtime-metadata
-./mvnw clean install
-cd ..
 
 echo "-- Authenticating (${DOCKER_HOST})"
 


### PR DESCRIPTION
* with updates to plugins and dependencies versions
* no longer have to build spring-boot-starter-runtime-metadata locally, now that we can source from Maven Central